### PR TITLE
Bugfix: default value reused due to reference

### DIFF
--- a/src/typerconf/init.nw
+++ b/src/typerconf/init.nw
@@ -123,14 +123,17 @@ Both work with these dot-separated addresses.
 class Config:
   """Navigates nested JSON structures by dot-separated addressing."""
 
-  def __init__(self, json_data={},
+  def __init__(self, json_data=None,
                      <<Config constructor args>>):
     """
     Constructs a config object to navigate from JSON data `json_data`.
 
     <<Config constructor args doc>>
     """
-    self.__data = json_data
+    if not json_data:
+      self.__data = {}
+    else:
+      self.__data = json_data
     <<Config attributes>>
 
   <<Config methods for get and set>>
@@ -138,7 +141,27 @@ class Config:
   <<Config methods for reading from and writing to file>>
 @
 
-We will use the following test data for the test functions.
+We want to test the constructor.
+<<test functions>>=
+def test_constructor():
+  test_key = "courses"
+  test_value = "test"
+
+  conf = Config(json_data={test_key: test_value})
+  assert test_key in conf.get()
+
+  assert test_key not in Config(json_data={}).get()
+  assert test_key not in Config().get()
+
+  conf = Config()
+  conf.set(test_key, test_value)
+  assert conf.get(test_key) == test_value
+
+  assert test_key not in Config().get()
+@
+
+We will use the following test data for the test functions in the remainder of 
+the text.
 <<test functions>>=
 test_data = {
   "courses": {
@@ -754,12 +777,14 @@ written to the file.
 <<test functions>>=
 def test_writeback_constructor():
   with tempfile.NamedTemporaryFile("w") as tmp_conf_file:
-    tmp_conf_file_name = "/tmp/writeback" #tmp_conf_file.name
+    tmp_conf_file_name = tmp_conf_file.name
     path = "the.path"
     first_value = "1st"
     second_value = "2nd"
 
     initial_conf = Config()
+    assert initial_conf.get() == {}
+
     initial_conf.set(path, first_value)
     initial_conf.write_config(tmp_conf_file_name)
 
@@ -768,6 +793,8 @@ def test_writeback_constructor():
     conf.set(path, second_value)
 
     last_conf = Config()
+    assert last_conf.get() == {}
+
     last_conf.read_config(tmp_conf_file_name)
     assert last_conf.get(path) == second_value
 <<test imports>>=


### PR DESCRIPTION
We suffered the bug where the default value was reused throughout, thus a new instance of Config() wasn't empty.

Fixed by using `None` as default value.

Also improved the tests to detect this bug.