### PR TITLE
Support typer 0.26 (vendored click), bump to 2.13

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -13,21 +13,6 @@ files = [
 ]
 
 [[package]]
-name = "click"
-version = "8.3.3"
-description = "Composable command line interface toolkit"
-optional = false
-python-versions = ">=3.10"
-groups = ["main"]
-files = [
-    {file = "click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613"},
-    {file = "click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2"},
-]
-
-[package.dependencies]
-colorama = {version = "*", markers = "platform_system == \"Windows\""}
-
-[[package]]
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
@@ -277,19 +262,19 @@ files = [
 
 [[package]]
 name = "typer"
-version = "0.25.1"
+version = "0.26.7"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "typer-0.25.1-py3-none-any.whl", hash = "sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89"},
-    {file = "typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc"},
+    {file = "typer-0.26.7-py3-none-any.whl", hash = "sha256:5c87cfbc5d34491c5346ebf49c23e18d56ccb863268d3a8d592b26087c2f5e58"},
+    {file = "typer-0.26.7.tar.gz", hash = "sha256:e314a34c617e419c091b2830dda3ea1f257134ff593061a8f5b9717ab8dddb3a"},
 ]
 
 [package.dependencies]
 annotated-doc = ">=0.0.2"
-click = ">=8.2.1"
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
 rich = ">=13.8.0"
 shellingham = ">=1.3.0"
 
@@ -309,4 +294,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "a7187795c467b6962e50128fc01008bf1ad7db3010ad3e7eb6b9b9f261bfa401"
+content-hash = "3c568fd29f60c78ecbd28b899e877fdedd3a9fce40e4241c0de449f59369d1e3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "typerconf"
-version = "2.12"
+version = "2.13"
 description = "Library to read and write configs using API and CLI with Typer"
 authors = ["Daniel Bosk <daniel@bosk.se>"]
 license = "MIT"
@@ -33,7 +33,7 @@ packages = [{include = "typerconf", from = "src"}]
 
 [tool.poetry.dependencies]
 python = "^3.10"
-typer = "^0.25.1"
+typer = ">=0.25.1"
 platformdirs = "^4.9.6"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
typer 0.26 vendors its own click and works with the existing
str-typed completion callback. Widen the typer constraint to a
floor only (>=0.25.1, no ceiling) so downstream projects can move
to the latest typer.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
